### PR TITLE
move to GNOME 3.30 runtime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/enchant-2.diff
+++ b/enchant-2.diff
@@ -1,0 +1,30 @@
+diff -u -r gtkspell-2.0.16/configure.ac gtkspell-2.0.16-enchant2/configure.ac
+--- gtkspell-2.0.16/configure.ac	2009-10-23 04:52:31.000000000 +0200
++++ gtkspell-2.0.16-enchant2/configure.ac	2018-01-18 12:42:06.366410232 +0100
+@@ -12,12 +12,12 @@
+ AM_INIT_AUTOMAKE(AC_PACKAGE_NAME, AC_PACKAGE_VERSION)
+ AC_CONFIG_HEADERS([config.h])
+ 
+-SPELLER_LIB=-lenchant
++SPELLER_LIB=-lenchant-2
+       
+ AC_SUBST(SPELLER_LIB)
+ GTKSPELL_PACKAGES=gtk+-2.0
+ AC_SUBST(GTKSPELL_PACKAGES)
+-PKG_CHECK_MODULES(GTKSPELL, $GTKSPELL_PACKAGES enchant >= 0.4.0 )
++PKG_CHECK_MODULES(GTKSPELL, $GTKSPELL_PACKAGES enchant-2 >= 2.2.0 )
+ AC_SUBST(GTKSPELL_CFLAGS)
+ AC_SUBST(GTKSPELL_LIBS)
+ 
+diff -u -r gtkspell-2.0.16/gtkspell/gtkspell.c gtkspell-2.0.16-enchant2/gtkspell/gtkspell.c
+--- gtkspell-2.0.16/gtkspell/gtkspell.c	2009-10-09 21:01:47.000000000 +0200
++++ gtkspell-2.0.16-enchant2/gtkspell/gtkspell.c	2018-01-18 12:41:37.146338802 +0100
+@@ -277,7 +277,7 @@
+ 	get_word_extents_from_mark(spell->buffer, &start, &end, spell->mark_click);
+ 	word = gtk_text_buffer_get_text(spell->buffer, &start, &end, FALSE);
+ 	
+-	enchant_dict_add_to_pwl( spell->speller, word, strlen(word));
++	enchant_dict_add( spell->speller, word, strlen(word));
+ 
+ 	gtkspell_recheck_all(spell);
+ 

--- a/im.pidgin.Pidgin.json
+++ b/im.pidgin.Pidgin.json
@@ -122,7 +122,10 @@
         "--enable-cyrus-sasl",
         "--disable-tk",
         "--disable-tcl",
-        "--disable-consoleui"
+        "--disable-consoleui",
+        "--disable-gnutls",
+        "--with-system-ssl-certs=/etc/ssl/certs",
+        "--disable-doxygen"
       ],
       "sources": [
         {

--- a/im.pidgin.Pidgin.json
+++ b/im.pidgin.Pidgin.json
@@ -1,143 +1,167 @@
 {
-  "id": "im.pidgin.Pidgin",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "3.30",
-  "sdk": "org.gnome.Sdk",
-  "command": "pidgin",
-  "rename-desktop-file": "pidgin.desktop",
-  "rename-icon": "pidgin",
-  "rename-appdata-file": "pidgin.appdata.xml",
-  "finish-args": [
-    "--share=ipc",
-    "--socket=x11",
-    "--share=network",
-    "--socket=pulseaudio",
-    "--persist=.purple",
-    "--filesystem=xdg-download",
-    "--filesystem=xdg-run/dconf",
-    "--filesystem=~/.config/dconf:ro",
-    "--talk-name=ca.desrt.dconf",
-    "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
-    "--talk-name=org.freedesktop.Notifications",
-    "--system-talk-name=org.freedesktop.Avahi"
-  ],
-  "cleanup": [
-    "/include",
-    "/share/man",
-    "/share/info",
-    "/share/gtk-doc",
-    "/share/aclocal",
-    "*.la",
-    "*.a"
-  ],
-  "modules": [
-    "shared-modules/gtk2/gtk2.json",
-    {
-      "name": "gtkspell",
-      "rm-configure": true,
-      "config-opts": [
-        "--disable-gtk-doc",
-        "--disable-static"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://sourceforge.net/projects/gtkspell/files/2.0.16/gtkspell-2.0.16.tar.gz",
-          "sha256": "8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02"
-        },
-        {
-          "type": "patch",
-          "path": "enchant-2.diff"
-        },
-        {
-          "type": "script",
-          "commands": [
-            "autoreconf -sfi"
-          ],
-          "dest-filename": "autogen.sh"
-        }
-      ]
-    },
-    {
-      "name": "libnice",
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.freedesktop.org/libnice/libnice.git",
-          "tag": "0.1.15",
-          "commit": "e25c3e5113c7b7002a78bcca2ecf058bbf7de6d4"
-        }
-      ]
-    },
-    {
-      "name": "farstream",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "http://freedesktop.org/software/farstream/releases/farstream/farstream-0.2.8.tar.gz",
-          "sha256": "2b3b9c6b4f64ace8c83e03d1da5c5a2884c1cae10b35471072b574201ab38908"
-        }
-      ]
-    },
-    {
-      "name": "avahi",
-      "cleanup": [ "/bin" ],
-      "config-opts": [
-        "--with-distro=none",
-        "--disable-libdaemon",
-        "--disable-core-docs",
-        "--disable-manpages",
-        "--disable-mono",
-        "--disable-qt3",
-        "--disable-qt4",
-        "--disable-python",
-        "--disable-gtk",
-        "--disable-gtk3",
-        "--disable-static"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://avahi.org/download/avahi-0.7.tar.gz",
-          "sha256": "57a99b5dfe7fdae794e3d1ee7a62973a368e91e414bd0dfa5d84434de5b14804"
-        }
-      ]
-    },
-    {
-      "name": "libidn",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://ftp.gnu.org/gnu/libidn/libidn-1.35.tar.gz",
-          "sha256": "f11af1005b46b7b15d057d7f107315a1ad46935c7fcdf243c16e46ec14f0fe1e"
-        }
-      ]
-    },
-    {
-      "name": "pidgin",
-      "config-opts": [
-        "--disable-static",
-        "--disable-meanwhile",
-        "--disable-nm",
-        "--enable-cyrus-sasl",
-        "--disable-tk",
-        "--disable-tcl",
-        "--disable-consoleui",
-        "--disable-gnutls",
-        "--with-system-ssl-certs=/etc/ssl/certs",
-        "--disable-doxygen"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://sourceforge.net/projects/pidgin/files/Pidgin/2.13.0/pidgin-2.13.0.tar.bz2",
-          "sha256": "2747150c6f711146bddd333c496870bfd55058bab22ffb7e4eb784018ec46d8f"
-        }
-      ],
-      "post-install": [
-        "chmod 755 /app/lib/pidgin/perl/auto/Pidgin/Pidgin.so",
-        "chmod 755 /app/lib/purple-2/perl/auto/Purple/Purple.so"
-      ]
-    }
-  ]
+	"id": "im.pidgin.Pidgin",
+	"runtime": "org.gnome.Platform",
+	"runtime-version": "3.30",
+	"sdk": "org.gnome.Sdk",
+	"command": "pidgin",
+	"rename-desktop-file": "pidgin.desktop",
+	"rename-icon": "pidgin",
+	"rename-appdata-file": "pidgin.appdata.xml",
+	"finish-args": [
+		"--share=ipc",
+		"--socket=x11",
+		"--share=network",
+		"--socket=pulseaudio",
+		"--persist=.purple",
+		"--filesystem=xdg-download",
+		"--filesystem=xdg-run/dconf",
+		"--filesystem=~/.config/dconf:ro",
+		"--talk-name=ca.desrt.dconf",
+		"--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+		"--talk-name=org.freedesktop.Notifications",
+		"--system-talk-name=org.freedesktop.Avahi"
+	],
+	"cleanup": [
+		"/include",
+		"/share/man",
+		"/share/info",
+		"/share/gtk-doc",
+		"/share/aclocal",
+		"*.la",
+		"*.a"
+	],
+	"modules": [
+		"shared-modules/gtk2/gtk2.json",
+		{
+			"name": "gtkspell",
+			"rm-configure": true,
+			"config-opts": [
+				"--disable-gtk-doc",
+				"--disable-static"
+			],
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://sourceforge.net/projects/gtkspell/files/2.0.16/gtkspell-2.0.16.tar.gz",
+					"sha256": "8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02"
+				},
+				{
+					"type": "patch",
+					"path": "enchant-2.diff"
+				},
+				{
+					"type": "script",
+					"commands": [
+						"autoreconf -sfi"
+					],
+					"dest-filename": "autogen.sh"
+				}
+			]
+		},
+		{
+			"name": "libnice",
+			"sources": [
+				{
+					"type": "git",
+					"url": "https://gitlab.freedesktop.org/libnice/libnice.git",
+					"tag": "0.1.15",
+					"commit": "e25c3e5113c7b7002a78bcca2ecf058bbf7de6d4"
+				}
+			]
+		},
+		{
+			"name": "farstream",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "http://freedesktop.org/software/farstream/releases/farstream/farstream-0.2.8.tar.gz",
+					"sha256": "2b3b9c6b4f64ace8c83e03d1da5c5a2884c1cae10b35471072b574201ab38908"
+				}
+			]
+		},
+		{
+			"name": "avahi",
+			"cleanup": [ "/bin" ],
+			"config-opts": [
+				"--with-distro=none",
+				"--disable-libdaemon",
+				"--disable-core-docs",
+				"--disable-manpages",
+				"--disable-mono",
+				"--disable-qt3",
+				"--disable-qt4",
+				"--disable-python",
+				"--disable-gtk",
+				"--disable-gtk3",
+				"--disable-static"
+			],
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://avahi.org/download/avahi-0.7.tar.gz",
+					"sha256": "57a99b5dfe7fdae794e3d1ee7a62973a368e91e414bd0dfa5d84434de5b14804"
+				}
+			]
+		},
+		{
+			"name": "libidn",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://ftp.gnu.org/gnu/libidn/libidn-1.35.tar.gz",
+					"sha256": "f11af1005b46b7b15d057d7f107315a1ad46935c7fcdf243c16e46ec14f0fe1e"
+				}
+			]
+		},
+		{
+			"name": "cyrus-sasl2",
+			"config-opts": [
+				"--with-dblib=berkeley",
+				"--without-pam",
+				"--without-opie",
+				"--without-des",
+				"--disable-gssapi",
+				"--enable-cram",
+				"--enable-digest",
+				"--enable-otp",
+				"--enable-plain",
+				"--enable-login",
+				"--with-plugindir=/app/lib/sasl2:/usr/lib/sasl2"
+			],
+			"no-parallel-make": true,
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://www.cyrusimap.org/releases/cyrus-sasl-2.1.27.tar.gz",
+					"sha256": "26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5"
+				}
+			]
+		},
+		{
+			"name": "pidgin",
+			"config-opts": [
+				"--disable-static",
+				"--disable-meanwhile",
+				"--disable-nm",
+				"--enable-cyrus-sasl",
+				"--disable-tk",
+				"--disable-tcl",
+				"--disable-consoleui",
+				"--disable-gnutls",
+				"--with-system-ssl-certs=/etc/ssl/certs",
+				"--disable-doxygen"
+			],
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://sourceforge.net/projects/pidgin/files/Pidgin/2.13.0/pidgin-2.13.0.tar.bz2",
+					"sha256": "2747150c6f711146bddd333c496870bfd55058bab22ffb7e4eb784018ec46d8f"
+				}
+			],
+			"post-install": [
+				"chmod 755 /app/lib/pidgin/perl/auto/Pidgin/Pidgin.so",
+				"chmod 755 /app/lib/purple-2/perl/auto/Purple/Purple.so"
+			]
+		}
+	]
 }

--- a/im.pidgin.Pidgin.json
+++ b/im.pidgin.Pidgin.json
@@ -122,11 +122,12 @@
 				"--without-des",
 				"--disable-gssapi",
 				"--enable-cram",
+				"--enable-scram",
 				"--enable-digest",
 				"--enable-otp",
 				"--enable-plain",
 				"--enable-login",
-				"--with-plugindir=/app/lib/sasl2:/usr/lib/sasl2"
+				"--with-plugindir=/app/lib/sasl2"
 			],
 			"no-parallel-make": true,
 			"sources": [

--- a/im.pidgin.Pidgin.json
+++ b/im.pidgin.Pidgin.json
@@ -1,7 +1,7 @@
 {
   "id": "im.pidgin.Pidgin",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.28",
+  "runtime-version": "3.30",
   "sdk": "org.gnome.Sdk",
   "command": "pidgin",
   "rename-desktop-file": "pidgin.desktop",
@@ -31,14 +31,23 @@
     "*.a"
   ],
   "modules": [
+    "shared-modules/gtk2/gtk2.json",
     {
       "name": "gtkspell",
       "rm-configure": true,
+      "config-opts": [
+        "--disable-gtk-doc",
+        "--disable-static"
+      ],
       "sources": [
         {
           "type": "archive",
           "url": "https://sourceforge.net/projects/gtkspell/files/2.0.16/gtkspell-2.0.16.tar.gz",
           "sha256": "8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02"
+        },
+        {
+          "type": "patch",
+          "path": "enchant-2.diff"
         },
         {
           "type": "script",
@@ -55,8 +64,8 @@
         {
           "type": "git",
           "url": "https://gitlab.freedesktop.org/libnice/libnice.git",
-          "tag": "0.1.14",
-          "commit": "6bfea0d063fb358a44e8800eae314520a2babd61"
+          "tag": "0.1.15",
+          "commit": "e25c3e5113c7b7002a78bcca2ecf058bbf7de6d4"
         }
       ]
     },
@@ -83,7 +92,8 @@
         "--disable-qt4",
         "--disable-python",
         "--disable-gtk",
-        "--disable-gtk3"
+        "--disable-gtk3",
+        "--disable-static"
       ],
       "sources": [
         {
@@ -94,12 +104,25 @@
       ]
     },
     {
+      "name": "libidn",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://ftp.gnu.org/gnu/libidn/libidn-1.35.tar.gz",
+          "sha256": "f11af1005b46b7b15d057d7f107315a1ad46935c7fcdf243c16e46ec14f0fe1e"
+        }
+      ]
+    },
+    {
       "name": "pidgin",
       "config-opts": [
+        "--disable-static",
         "--disable-meanwhile",
         "--disable-nm",
         "--enable-cyrus-sasl",
-        "--disable-tk"
+        "--disable-tk",
+        "--disable-tcl",
+        "--disable-consoleui"
       ],
       "sources": [
         {


### PR DESCRIPTION
Let's try to move to the new runtime. It removed gtk2 so I am using the shared-modules gtk2 now