### PR TITLE
Patch the .desktop file to include the correct StartupWMClass

### DIFF
--- a/add_wm_class.patch
+++ b/add_wm_class.patch
@@ -1,0 +1,22 @@
+From 339ccaf7cc170c90f9f888de0e1c2e99620b7d05 Mon Sep 17 00:00:00 2001
+From: Stan Janssen <stan@finetuned.nl>
+Date: Wed, 15 Dec 2021 10:26:15 +0100
+Subject: [PATCH] Add StartupWMClass to .desktop
+
+---
+ pidgin/data/pidgin.desktop.in.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pidgin/data/pidgin.desktop.in.in b/pidgin/data/pidgin.desktop.in.in
+index 7662fae..c4161ff 100644
+--- a/pidgin/data/pidgin.desktop.in.in
++++ b/pidgin/data/pidgin.desktop.in.in
+@@ -8,4 +8,5 @@ StartupNotify=true
+ Terminal=false
+ Type=Application
+ Categories=Network;InstantMessaging;
++StartupWMClass=Pidgin
+ @USES_MM_CHAT_SECTION@
+-- 
+2.25.1
+

--- a/im.pidgin.Pidgin.json
+++ b/im.pidgin.Pidgin.json
@@ -191,6 +191,10 @@
         {
           "type": "patch",
           "path": "appdata.patch"
+        },
+        {
+          "type": "patch",
+          "path": "add_wm_class.patch"
         }
       ],
       "post-install": [


### PR DESCRIPTION
This solves a problem on the elementaryOS Dock where a second Dock icon would pop up. Until this is fixed in the elementaryOS Dock itself, this is the quickest and most pain-free way to solve the problem for users.

Please see https://github.com/elementary/dock/issues/64 for examples of this.