### PR TITLE
Add retro-prpl

### DIFF
--- a/im.pidgin.Pidgin.json
+++ b/im.pidgin.Pidgin.json
@@ -199,6 +199,7 @@
         },
         "plugins/pidgin-otr.json",
         "plugins/purple-plugin-pack.json",
-        "plugins/bot-sentry/bot-sentry.json"
+        "plugins/bot-sentry/bot-sentry.json",
+        "plugins/retro-prpl.json"
     ]
 }

--- a/plugins/retro-prpl.json
+++ b/plugins/retro-prpl.json
@@ -1,0 +1,19 @@
+{
+  "name": "retro-prpl",
+  "buildsystem": "meson",
+  "config-opts": [
+    "-Dbuildtype=release",
+    "-Dsilc10=disabled",
+    "-Dsilc=disabled",
+    "-Dnovell=disabled",
+    "-Dzephyr=disabled",
+    "-Dgadu-gadu=disabled"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/pidgin/retro-prpl.git",
+      "commit": "5f1669b9305b912c02fe2daacd7e77fd0da2c748"
+    }
+  ]
+}


### PR DESCRIPTION
retro-prpl is a collection of all proprietary protocols plugins that have ever been in the pidgin codebase. With the retro chat craze in full swing these plugins were extracted to make them easily accessible.

A bunch of them had to be disabled in this commit due to them still existing in Pidgin 2.14.14. However, they have been removed for the upcoming Pidgin 2.15.0 release and then may be re-enabled here.