### PR TITLE
Update GNOME runtime to 50

### DIFF
--- a/im.pidgin.Pidgin.json
+++ b/im.pidgin.Pidgin.json
@@ -1,7 +1,7 @@
 {
     "id": "im.pidgin.Pidgin",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "pidgin",
     "rename-icon": "pidgin",
@@ -165,12 +165,12 @@
                     "type": "archive",
                     "url": "https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.tar.gz",
                     "sha256": "c6c7c27fadc19d40ab2eaa23ff35debfe01f6494a8345559b9bb285ce4144dd1",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 3715,
-                        "stable-only": true,
-                        "url-template": "https://github.com/protocolbuffers/protobuf/releases/download/v$version/protobuf-$version.tar.gz"
-                    }
+//                    "x-checker-data": {
+//                        "type": "anitya",
+//                        "project-id": 3715,
+//                        "stable-only": true,
+//                        "url-template": "https://github.com/protocolbuffers/protobuf/releases/download/v$version/protobuf-$version.tar.gz"
+//                    }
                 }
             ]
         },

--- a/im.pidgin.Pidgin.json
+++ b/im.pidgin.Pidgin.json
@@ -1,7 +1,7 @@
 {
     "id": "im.pidgin.Pidgin",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "pidgin",
     "rename-icon": "pidgin",
@@ -164,13 +164,7 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.tar.gz",
-                    "sha256": "c6c7c27fadc19d40ab2eaa23ff35debfe01f6494a8345559b9bb285ce4144dd1",
-//                    "x-checker-data": {
-//                        "type": "anitya",
-//                        "project-id": 3715,
-//                        "stable-only": true,
-//                        "url-template": "https://github.com/protocolbuffers/protobuf/releases/download/v$version/protobuf-$version.tar.gz"
-//                    }
+                    "sha256": "c6c7c27fadc19d40ab2eaa23ff35debfe01f6494a8345559b9bb285ce4144dd1"
                 }
             ]
         },

--- a/plugins/pidgin-otr.json
+++ b/plugins/pidgin-otr.json
@@ -44,8 +44,8 @@
                 {
                     "type": "git",
                     "url": "https://dev.gnupg.org/source/libgcrypt.git",
-                    "tag": "libgcrypt-1.12.0",
-                    "commit": "efd5e1e7b4e7861b53eafdbf197fd6d4ff6f45e1",
+                    "tag": "libgcrypt-1.12.1",
+                    "commit": "7e91b2a334d568297b7d81e05acd74e1d841b69d",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1623,

--- a/plugins/purple-plugin-pack.json
+++ b/plugins/purple-plugin-pack.json
@@ -1,6 +1,9 @@
 {
   "name": "purple-plugin-pack",
   "buildsystem": "meson",
+  "build-options": {
+    "cflags": "-Wno-error=incompatible-pointer-types"
+  },
   "sources": [
     {
       "type": "archive",


### PR DESCRIPTION
- update runtime to 50
- lock protobuf to v33.5 since v34.0 released recently does not build
- add compiler flag to make purple-plugin-pack buildable